### PR TITLE
Fix layout placeholders on about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -67,13 +67,8 @@
 <body>
   <!-- HEADER (injected) -->
   <div id="header-placeholder"></div>
+
   <!-- MAIN CONTENT (აქ ჩასვი შენი ბლოკები) -->
-</body>
-</html>
-
-  <!-- HEADER (injected) -->
-  <div id="header-placeholder"></div>
-
   <main id="content" class="container" aria-label="Main content">
     <div class="about-wrap">
 


### PR DESCRIPTION
## Summary
- remove duplicated header placeholder and premature closing tags from `about.html`
- ensure the header, main content, and footer placeholders appear once in the correct order

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daf90d56dc8328a09549f618793204